### PR TITLE
Edit event times to fit travel

### DIFF
--- a/app/controllers/itineraries_controller.rb
+++ b/app/controllers/itineraries_controller.rb
@@ -20,7 +20,7 @@ class ItinerariesController < ApplicationController
       itinerary_template = ItineraryTemplate.new(itinerary_params).perform
 
       PopulateItinerary.new({ itinerary: @itinerary, template: itinerary_template, params: itinerary_params }).perform
-      SetTravelTime.new
+      SetTravelTime.new(@itinerary).perform
 
       redirect_to itinerary_path(@itinerary)
     else

--- a/app/services/itinerary_template.rb
+++ b/app/services/itinerary_template.rb
@@ -262,7 +262,8 @@ class ItineraryTemplate < ApplicationRecord
         filter_type: INTEREST_VALUES[:"#{event}"][:filter_type],
         filter_ratings: INTEREST_VALUES[:"#{event}"][:filter_ratings],
         event_start_time: event_start.strftime('%H:%M'),
-        event_end_time: event_end.strftime('%H:%M')
+        event_end_time: event_end.strftime('%H:%M'),
+        event_duration: INTEREST_VALUES[:"#{event}"][:time]
       }
     end
 

--- a/app/services/populate_event.rb
+++ b/app/services/populate_event.rb
@@ -24,8 +24,7 @@ class PopulateEvent < ApplicationRecord
     event.end_time = @event_details[:event_end_time]
     event.order_number = @event_details[:order_number]
     event.alternative_places = @alternative_places
-
-
+    event.event_duration = @event_details[:event_duration]
 
     if Place.find_by(search_place_details_id: @search_place_details[:place_id])
       event.place = Place.find_by(search_place_details_id: @search_place_details[:place_id])

--- a/app/services/set_travel_time.rb
+++ b/app/services/set_travel_time.rb
@@ -1,2 +1,87 @@
+require "uri"
+require "net/http"
+require "json"
+require "open-uri"
+
 class SetTravelTime < ApplicationRecord
+  def initialize(itinerary)
+    @itinerary = itinerary
+  end
+
+  def perform
+    add_travel_to_schedule
+  end
+
+  private
+
+  def add_travel_to_schedule
+    start_location = "#{@itinerary.latitude},#{@itinerary.longitude}"
+    start_date = @itinerary[:date].strftime('%Y%m%d')
+    start_time = @itinerary[:start_time].strftime('%H%M')
+
+
+    @itinerary.events.each do |event|
+      # event_duration = @
+
+
+      destination_location = event.place.search_geometry_location
+
+      url = generate_url(start_location, destination_location, start_time, start_date)
+      directions = fetch_directions(url)
+
+      event.directions_to_event = directions
+
+      hours = start_time.first(2)
+      minutes = start_time.last(2)
+      time = Time.new(1, 1, 1, hours, minutes, 0)
+      start_time = time + (directions[:journey_duration].to_i * 60)
+
+      start_time = calculate_time(start_time)
+
+      min = start_time.min
+      hour = start_time.hour
+
+
+
+    end
+  end
+
+  def generate_url(start_location, destination_location, start_time, start_date)
+    mode = "bus,overground,tube,coach,dlr"
+    URI("https://api.tfl.gov.uk/Journey/JourneyResults/#{start_location}/to/#{destination_location}?date=#{start_date}&time=#{start_time}&timeIs=Departing&journeyPreference=LeastTime&mode=#{mode}&walkingSpeed=Average")
+  end
+
+  def fetch_directions(url)
+    https = Net::HTTP.new(url.host, url.port)
+    https.use_ssl = true
+
+    request = Net::HTTP::Get.new(url)
+
+    response = https.request(request)
+    response_json = response.read_body
+    search_data = JSON.parse(response_json)
+
+    journey_duration = search_data["journeys"].first["duration"]
+    journey_legs = search_data["journeys"].first["legs"].map do |leg|
+      "#{leg["instruction"]["summary"]} (#{leg["duration"]} mins)"
+    end
+
+    {
+      journey_duration: journey_duration,
+      journey_legs: journey_legs
+    }
+  end
+
+  def calculate_time
+    while (min % 5).positive?
+      min += 1
+      if min == 60
+        min = 0
+        hour += 1
+        hour = 0 if hour == 24
+      end
+    end
+
+    Time.new(1, 1, 1, hour, min, 0)
+  end
 end

--- a/db/migrate/20230313093609_add_event_duration_to_events.rb
+++ b/db/migrate/20230313093609_add_event_duration_to_events.rb
@@ -1,0 +1,5 @@
+class AddEventDurationToEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :events, :event_duration, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_12_185125) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_13_093609) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,6 +52,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_12_185125) do
     t.string "order_number"
     t.jsonb "alternative_places", default: {}
     t.jsonb "directions_to_event", default: {}
+    t.integer "event_duration"
     t.index ["itinerary_id"], name: "index_events_on_itinerary_id"
     t.index ["place_id"], name: "index_events_on_place_id"
   end


### PR DESCRIPTION
After Itinerary has been populated with events (with places), the Itinerary controller calls the SetTravelTime service class

This class iterates through each event and calls the TFL API to get accurate travel information for the specified date/time and returns a hash with a journey duration and array of simple travel instructions.

start/end times for each event are then calculated using the new travel information.

Tested with Places API calls and works. Logic added so that, if TFL API does not respond with travel details, the duration is set to 15mins and the instructions is set to an empty array.

Above also catches issues with place locations outside of London (so not covered by TFL API).