### PR TITLE
Recalculates timings and directionds after event order update with so…

### DIFF
--- a/app/controllers/itineraries_controller.rb
+++ b/app/controllers/itineraries_controller.rb
@@ -55,6 +55,9 @@ class ItinerariesController < ApplicationController
 
     # assigns correct order_number value to each event
     event_order.length.times { |i| @events[event_order[i]].update(order_number: i + 1) }
+
+    #recalculate Itinerary timings with updated travel instructions
+    SetTravelTime.new(@itinerary).perform
   end
 
   def set_events

--- a/app/javascript/controllers/sortable.js
+++ b/app/javascript/controllers/sortable.js
@@ -26,7 +26,7 @@ const initSortable = () => {
       })
       setTimeout(function() {
         location.reload();
-      }, 50);
+      }, 2000);
     }
   })
 }

--- a/app/services/set_travel_time.rb
+++ b/app/services/set_travel_time.rb
@@ -20,7 +20,9 @@ class SetTravelTime < ApplicationRecord
     start_date = @itinerary[:date].strftime('%Y%m%d')
     end_time = @itinerary[:start_time].strftime('%H%M')
 
-    @itinerary.events.each do |event|
+    events = @itinerary.events.order(:order_number)
+
+    events.each do |event|
       start_time = end_time
 
       destination_location = event.place.search_geometry_location

--- a/app/views/itineraries/_event_infos.html.erb
+++ b/app/views/itineraries/_event_infos.html.erb
@@ -52,6 +52,10 @@
 
     <%# details %>
     <div class="d-none zoom" data-edit-event-target="details" style="min-width:150px; max-height:300px"; >
+        <p><%= event.directions_to_event["journey_duration"] %></p>
+        <% event.directions_to_event["journey_legs"].each do |leg| %>
+          <li><%= leg %></li>
+        <% end %>
         <h2>Description: </h2><%= event.place.details_overview %> <br>
         <h2>Address: </h2><%= event.place.details_formatted_address %>
         <a href="<%= event.place.details_url %>" target="_blank"><i class="fa-solid fa-location-dot"></i></a></p>


### PR DESCRIPTION
SetTravelTime service class called on end of edit_order algorithm after the Sortable event end.

Temporary solution to automatically refreshing the screen edited to delayed for two seconds to allow time for BE to update database.

Temporary directions information added to the Event cards for testing purposes.

We will need to find a better solution for the page refresh, if we can. It might just need to be AJAX